### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@
 # Classes (KEYWORD1)
 ###############################################################
 
-EEPROM		KEYWORD1
+EEPROM	KEYWORD1
 
 ###############################################################
 # Datatypes (KEYWORD1)
@@ -17,7 +17,7 @@ EEPROM		KEYWORD1
 # Methods and Functions (KEYWORD2)
 ###############################################################
 
-begin		KEYWORD2
+begin	KEYWORD2
 write_byte	KEYWORD2
 read_byte	KEYWORD2
 erase_byte	KEYWORD2


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style highlighting  to be used (as with KEYWORD2, KEYWORD3). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special highlighting.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords