### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,7 +6,7 @@
 # Classes (KEYWORD1)
 ###############################################################
 
-EEPROM  KEYWORD1
+EEPROM	KEYWORD1
 
 ###############################################################
 # Datatypes (KEYWORD1)
@@ -17,11 +17,11 @@ EEPROM  KEYWORD1
 # Methods and Functions (KEYWORD2)
 ###############################################################
 
-begin KEYWORD2
-write_byte  KEYWORD2
-read_byte KEYWORD2
-erase_byte  KEYWORD2
-write_string  KEYWORD2
+begin	KEYWORD2
+write_byte	KEYWORD2
+read_byte	KEYWORD2
+erase_byte	KEYWORD2
+write_string	KEYWORD2
 
 ###############################################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords